### PR TITLE
fix add to cart button if adding a product already in cart

### DIFF
--- a/Description/Description.js
+++ b/Description/Description.js
@@ -20,6 +20,20 @@ let dataTotal2=JSON.parse(localStorage.getItem('dataTotal'))
 let idProduct2 =JSON.parse(localStorage.getItem('idProduct'))
 let quantity2=quantityText2.textContent;
 
+//Action 1: if product added is already in Cart
+if(cart.find((element)=>element.id==idProduct2)!=null){
+  // find product on cart
+  let product=cart.find((element)=>element.id==idProduct2)
+  //find location in cart
+  let index = cart.indexOf(product)
+  //Add quantity to the product
+  cart[index].quantity=parseInt(cart[index].quantity)+parseInt(quantity2)
+  // save back new cart array in local storage
+  localStorage.setItem('cart',JSON.stringify(cart)) 
+} 
+
+//Action 2: if product in not in cart in local storage
+else{
 //find the product in dataTotal array using idProduct
 let product=dataTotal2.find((element)=>element.id==idProduct2)
 //Add quantity to the product
@@ -27,6 +41,7 @@ product.quantity=quantity2;
 //push in the cart and save in local storage
 cart.push(product)
 localStorage.setItem('cart',JSON.stringify(cart))
+}
 // Move to Main page
 window.location.href = "../MainPage/MainPage.html";
 

--- a/ShoppingCart/ShoppingCart.css
+++ b/ShoppingCart/ShoppingCart.css
@@ -25,8 +25,7 @@
   .allCart {
     display: flex;
     flex-wrap: wrap;
-    /* width: 375px; */
-    position: relative;
+    align-content: flex-start;
     height: 70vh;
     margin: 20px 0px 0px 0px;
     overflow: scroll;


### PR DESCRIPTION
Relates #89

I added `if condition`
If the product is already in cart > just add the current quantity to quantity in cart and do not push the product as new product.

Example:

Add this product
![image](https://user-images.githubusercontent.com/83221547/129235609-58e54738-d741-45f8-aabd-52d07c16c0ad.png)

See Cart
![image](https://user-images.githubusercontent.com/83221547/129235691-390a63a7-af49-4473-8d9a-bc7f26af803b.png)

Add it again,
![image](https://user-images.githubusercontent.com/83221547/129235811-bfd45e73-c3cf-462b-8db5-98a604d1bc39.png)


See how quantity increased instead of adding it as a new product
![image](https://user-images.githubusercontent.com/83221547/129235928-40e1aac1-428d-4247-a6fd-692f7b772bed.png)

